### PR TITLE
Add an optional always-on bar graph

### DIFF
--- a/ActivityController.qml
+++ b/ActivityController.qml
@@ -14,8 +14,16 @@ Item {
 
   property var settings: ({})
   property bool active: false
+  property bool background: false
   property bool expanded: false
   property bool processPowerEnabled: true
+
+  // Sampling runs in two tiers. While the panel is open (`active`) every
+  // reader is scheduled. While it is closed and the bar graph is enabled
+  // (`background`) only the resources reader runs, on a slower cadence, so a
+  // closed panel still costs almost nothing.
+  readonly property bool sampling: active || background
+  property bool _sessionRunning: false
 
   readonly property string statsHelperPath: decodeURIComponent(
     String(Qt.resolvedUrl("activity-sampler")).replace("file://", ""))
@@ -50,6 +58,7 @@ Item {
   readonly property int gpuRefreshInterval: intervalSetting("gpuRefreshIntervalMs", 2000, 1000, 15000, samplingProfile.gpus)
   readonly property int storageRefreshInterval: intervalSetting("storageRefreshIntervalMs", 30000, 10000, 120000, samplingProfile.storage)
   readonly property int historySamples: boundedSetting("historySamples", 60, 20, 240)
+  readonly property int backgroundRefreshInterval: boundedSetting("backgroundRefreshIntervalMs", 3000, 1000, 30000)
 
   property var _snapshot: Model.emptySnapshot()
   property var _thermalSnapshot: Model.emptyThermalSnapshot()
@@ -109,46 +118,60 @@ Item {
 
   function scheduleNextDeadline() {
     deadlineScheduler.stop()
-    if (!active) return
+    if (!sampling) return
 
-    var next = Math.min(_resourceDue, _processDue, _thermalDue, _storageDue)
-    if (expanded && _gpuDue > 0) next = Math.min(next, _gpuDue)
+    var candidates = active
+      ? [_resourceDue, _processDue, _thermalDue, _storageDue, expanded ? _gpuDue : 0]
+      : [_resourceDue]
+    var next = 0
+    for (var i = 0; i < candidates.length; i++) {
+      var due = Number(candidates[i])
+      if (!isFinite(due) || due <= 0) continue
+      if (next <= 0 || due < next) next = due
+    }
+    if (next <= 0) return
     deadlineScheduler.interval = Math.max(1, Math.round(next - Date.now()))
     deadlineScheduler.start()
   }
 
+  function resourceInterval() {
+    return active ? refreshInterval : backgroundRefreshInterval
+  }
+
   function resetPeriodicDeadlines() {
     var now = Date.now()
-    _resourceDue = now + refreshInterval
-    _processDue = now + processRefreshInterval
-    _thermalDue = now + thermalRefreshInterval
-    _storageDue = now + storageRefreshInterval
-    _gpuDue = expanded ? now + gpuRefreshInterval : 0
+    _resourceDue = now + resourceInterval()
+    _processDue = active ? now + processRefreshInterval : 0
+    _thermalDue = active ? now + thermalRefreshInterval : 0
+    _storageDue = active ? now + storageRefreshInterval : 0
+    _gpuDue = active && expanded ? now + gpuRefreshInterval : 0
     scheduleNextDeadline()
   }
 
   function collectDueSnapshots() {
-    if (!active) return
+    if (!sampling) return
     var now = Date.now()
-    if (_resourceDue <= now + 1) {
+    if (_resourceDue > 0 && _resourceDue <= now + 1) {
       refreshResources()
-      _resourceDue = nextDeadline(_resourceDue, refreshInterval, now)
+      _resourceDue = nextDeadline(_resourceDue, resourceInterval(), now)
     }
-    if (_processDue <= now + 1) {
-      refreshProcessCycle()
-      _processDue = nextDeadline(_processDue, processRefreshInterval, now)
-    }
-    if (_thermalDue <= now + 1) {
-      refreshThermals()
-      _thermalDue = nextDeadline(_thermalDue, thermalRefreshInterval, now)
-    }
-    if (_storageDue <= now + 1) {
-      refreshStorage()
-      _storageDue = nextDeadline(_storageDue, storageRefreshInterval, now)
-    }
-    if (expanded && _gpuDue > 0 && _gpuDue <= now + 1) {
-      refreshGpus()
-      _gpuDue = nextDeadline(_gpuDue, gpuRefreshInterval, now)
+    if (active) {
+      if (_processDue > 0 && _processDue <= now + 1) {
+        refreshProcessCycle()
+        _processDue = nextDeadline(_processDue, processRefreshInterval, now)
+      }
+      if (_thermalDue > 0 && _thermalDue <= now + 1) {
+        refreshThermals()
+        _thermalDue = nextDeadline(_thermalDue, thermalRefreshInterval, now)
+      }
+      if (_storageDue > 0 && _storageDue <= now + 1) {
+        refreshStorage()
+        _storageDue = nextDeadline(_storageDue, storageRefreshInterval, now)
+      }
+      if (expanded && _gpuDue > 0 && _gpuDue <= now + 1) {
+        refreshGpus()
+        _gpuDue = nextDeadline(_gpuDue, gpuRefreshInterval, now)
+      }
     }
     scheduleNextDeadline()
   }
@@ -190,14 +213,14 @@ Item {
   }
 
   function startStatsReader() {
-    if (!active || statsReaderProc.running) return
+    if (!sampling || statsReaderProc.running) return
     _statsReaderReady = false
     _statsReaderBuffer = []
     statsReaderProc.running = true
   }
 
   function sendStatsRequest(kind) {
-    if (!active || statsPending(kind)) return
+    if (!sampling || statsPending(kind)) return
     setStatsPending(kind, true)
     statsReaderWatchdog.restart()
     if (!statsReaderProc.running) startStatsReader()
@@ -314,6 +337,7 @@ Item {
 
   function refresh() {
     refreshResources()
+    if (!active) return
     refreshProcessCycle()
     refreshThermals()
     refreshGpus()
@@ -329,7 +353,7 @@ Item {
       _metrics = Model.baselineMetrics(next, metrics)
       _previousSnapshot = next
       _snapshot = next
-      if (active) resourceWarmup.restart()
+      if (sampling) resourceWarmup.restart()
       return
     }
     _metrics = Model.nextMetrics(_previousSnapshot, next, metrics, historySamples)
@@ -460,9 +484,30 @@ Item {
     statsReaderRetry.stop()
   }
 
+  // Start/stop on the tier, not on a transition: with the bar graph enabled
+  // `sampling` is already true when the component is created, so relying on the
+  // change signal alone would never open the session.
+  function syncSession() {
+    if (sampling && !_sessionRunning) {
+      _sessionRunning = true
+      startSession()
+    } else if (!sampling && _sessionRunning) {
+      _sessionRunning = false
+      stopSession()
+    }
+  }
+
+  Component.onCompleted: syncSession()
+
+  onSamplingChanged: syncSession()
+
+  // Opening or closing the panel while the background tier keeps the session
+  // alive swaps cadences in place. History survives, so the bar graph does not
+  // blank out on every open.
   onActiveChanged: {
-    if (active) startSession()
-    else stopSession()
+    if (!_sessionRunning) return
+    if (active) refresh()
+    resetPeriodicDeadlines()
   }
 
   onExpandedChanged: {
@@ -495,6 +540,7 @@ Item {
   }
 
   onRefreshIntervalChanged: if (active) resetPeriodicDeadlines()
+  onBackgroundRefreshIntervalChanged: if (_sessionRunning && !active) resetPeriodicDeadlines()
   onProcessRefreshIntervalChanged: if (active) resetPeriodicDeadlines()
   onThermalRefreshIntervalChanged: if (active) resetPeriodicDeadlines()
   onGpuRefreshIntervalChanged: if (active) resetPeriodicDeadlines()
@@ -513,7 +559,7 @@ Item {
     }
     onExited: {
       root.resetStatsReaderState()
-      if (root.active) statsReaderRetry.restart()
+      if (root.sampling) statsReaderRetry.restart()
     }
   }
 
@@ -572,14 +618,14 @@ Item {
     id: statsReaderRetry
     interval: 250
     repeat: false
-    onTriggered: if (root.active) root.refresh()
+    onTriggered: if (root.sampling) root.refresh()
   }
 
   Timer {
     id: resourceWarmup
     interval: 300
     repeat: false
-    onTriggered: if (root.active) root.refreshResources()
+    onTriggered: if (root.sampling) root.refreshResources()
   }
 
   Timer {

--- a/Panel.qml
+++ b/Panel.qml
@@ -13,6 +13,9 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
+  // Bar orientation is lifted off the host the same way Ui/BarWidget does it.
+  readonly property bool vertical: bar ? bar.vertical : false
+
   property bool expanded: false
   property bool settingsOpen: false
   property bool settingsControlActive: false
@@ -104,6 +107,23 @@ Panel {
   readonly property int historySamplesSetting: Math.max(20, Math.min(240,
     Math.round(Number(setting("historySamples", 60)) || 60)))
   readonly property string temperatureUnitSetting: normalizedTemperatureUnit(setting("temperatureUnit", "Celsius"))
+  readonly property string barGraphSetting: normalizedBarGraph(setting("barGraph", "Off"))
+  readonly property bool barGraphEnabled: barGraphSetting !== "Off"
+  // 0 means "square": match the bar's thickness so the graph reads as a tile.
+  readonly property int barGraphLengthSetting: Math.max(0, Math.min(160,
+    Number(setting("barGraphLength", 0)) || 0))
+  // Square means "the footprint the icon just gave up", so the graph lines up
+  // with every other widget slot on the bar.
+  readonly property int barGraphLength: barGraphLengthSetting > 0
+    ? barGraphLengthSetting
+    : Style.bar.iconSlot
+  readonly property var barGraphValues: barGraphSetting === "Memory"
+    ? metrics.memoryHistory
+    : metrics.cpuHistory
+  readonly property real barGraphLatest: barGraphSetting === "Memory" ? metrics.memory : metrics.cpu
+  readonly property string barGraphSummary: "CPU " + percentText(metrics.cpu)
+    + "  ·  RAM " + percentText(metrics.memory)
+  readonly property color barGraphTone: barGraphLatest >= 90 ? root.urgent : root.accent
   readonly property bool showFrequencies: booleanSetting("showFrequencies", true)
   readonly property bool openExpandedByDefault: booleanSetting("openExpanded", false)
   readonly property bool powerEstimatesEnabled: booleanSetting("processPowerEnabled", true)
@@ -229,6 +249,13 @@ Panel {
     return value === undefined || value === null ? fallback : !!value
   }
 
+  function normalizedBarGraph(value) {
+    var normalized = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
+    if (normalized === "cpu") return "CPU"
+    if (normalized === "memory" || normalized === "ram") return "Memory"
+    return "Off"
+  }
+
   function normalizedSamplingSpeed(value) {
     return Model.samplingProfile(value).name
   }
@@ -264,7 +291,9 @@ Panel {
       temperatureUnit: "Celsius",
       showFrequencies: true,
       openExpanded: false,
-      processPowerEnabled: true
+      processPowerEnabled: true,
+      barGraph: "Off",
+      barGraphLength: 0
     })
   }
 
@@ -577,6 +606,7 @@ Panel {
     id: activity
     settings: root.settings
     active: root.opened
+    background: root.barGraphEnabled
     expanded: root.expanded
     processPowerEnabled: root.powerEstimatesEnabled
   }
@@ -595,13 +625,52 @@ Panel {
     referenceItem: root.processViewport
   }
 
+  // The graph rides inside the bar's own button rather than a bare MouseArea:
+  // ModuleSlot overlays every widget with its drag-reorder pointer and only
+  // dispatches presses to registered click targets, so a plain MouseArea would
+  // never see a click. iconComponent is the supported way in, and it brings the
+  // tooltip and hover handling with it.
   BarIconButton {
     id: button
     anchors.fill: parent
     bar: root.bar
     text: "\uf201"
-    tooltipText: "Activity"
+    iconComponent: root.barGraphEnabled ? barGraphComponent : null
+    slotSize: root.barGraphEnabled ? root.barGraphLength : Style.bar.iconSlot
+    opticalSize: root.barGraphEnabled ? root.barGraphLength : Style.bar.iconCanvas
+    tooltipText: root.barGraphEnabled ? root.barGraphSummary : "Activity"
     onPressed: function(buttonCode) { root.toggle() }
+  }
+
+  Component {
+    id: barGraphComponent
+
+    // The optical canvas is square at the graph's length; the trace keeps its
+    // own bounded height and centers, so a wide graph stays a bar-height strip.
+    Item {
+      Sparkline {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height: Math.max(Style.space(10), Math.min(parent.height, Style.bar.iconCanvas))
+        values: root.barGraphValues
+        ceiling: 100
+        lineColor: root.barGraphTone
+        fillColor: Util.alpha(root.barGraphTone, 0.16)
+      }
+    }
+  }
+
+  // showTooltip takes a snapshot of the text, so a tooltip opened over the
+  // graph would otherwise freeze at the reading it had on entry.
+  HoverHandler { id: barHover }
+
+  Connections {
+    target: root
+    function onBarGraphSummaryChanged() {
+      if (barHover.hovered && root.bar && root.barGraphEnabled)
+        root.bar.showTooltip(button, root.barGraphSummary)
+    }
   }
 
   KeyboardPanel {
@@ -618,9 +687,15 @@ Panel {
     contentWidth: panel.fittedContentWidth(root.settingsOpen
       ? Style.space(600)
       : (root.expanded ? Style.space(780) : Style.space(380)))
+    // Settings gets its own cap: the preference grid is a row taller than the
+    // detail view's budget allows, and a clipped settings page hides controls
+    // rather than merely cropping a view. fittedContentHeight still clamps to
+    // the space the screen actually has.
     contentHeight: panel.fittedContentHeight(
       contentLoader.item ? contentLoader.item.implicitHeight : Style.space(320),
-      root.expanded || root.settingsOpen ? Style.space(720) : Style.space(560))
+      root.settingsOpen
+        ? Style.space(860)
+        : (root.expanded ? Style.space(720) : Style.space(560)))
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -940,6 +1015,41 @@ Panel {
               accent: root.accent
               fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
               onChanged: function(next) { root.persistSettings({ temperatureUnit: next }) }
+            }
+
+            Dropdown {
+              width: (preferenceGrid.width
+                - preferenceGrid.columnSpacing * (preferenceGrid.columns - 1))
+                / preferenceGrid.columns
+              label: "Bar graph"
+              value: root.barGraphSetting
+              options: [
+                { value: "Off", label: "Off · panel only" },
+                { value: "CPU", label: "CPU · always sampling" },
+                { value: "Memory", label: "Memory · always sampling" }
+              ]
+              foreground: root.foreground
+              accent: root.accent
+              fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+              onChanged: function(next) { root.persistSettings({ barGraph: next }) }
+            }
+
+            Dropdown {
+              width: (preferenceGrid.width
+                - preferenceGrid.columnSpacing * (preferenceGrid.columns - 1))
+                / preferenceGrid.columns
+              label: "Bar graph width"
+              value: String(root.barGraphLengthSetting)
+              options: [
+                { value: "0", label: "Square · matches the bar" },
+                { value: "44", label: "Wide · 44 px" },
+                { value: "72", label: "Wider · 72 px" },
+                { value: "110", label: "Widest · 110 px" }
+              ]
+              foreground: root.foreground
+              accent: root.accent
+              fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+              onChanged: function(next) { root.persistSettings({ barGraphLength: Number(next) }) }
             }
 
             Toggle {

--- a/README.md
+++ b/README.md
@@ -33,10 +33,30 @@ omarchy plugin remove stappmus.activity-monitor
 
 - Click the bar icon to open. `e` expands, Esc collapses.
 - `/` search processes. `j` / `k` move. Click a column header to sort.
-- `s` opens settings — update speed, graph history, °C/°F, and whether to estimate process watts.
+- `s` opens settings — update speed, graph history, °C/°F, the bar graph, and
+  whether to estimate process watts.
 - `x` can close an app you selected, after a confirmation.
 
 Settings are saved with your bar layout and apply immediately.
+
+## The bar graph
+
+Off by default. Set it to CPU or Memory in settings and the bar icon is replaced
+by a live sparkline, themed like the rest of the panel. It behaves exactly like
+the icon it stands in for: click to open, hover for a quick CPU and RAM reading.
+
+Width is a setting too. The default is square — the same slot the icon occupied,
+so it lines up with everything else on the bar — and 44, 72, or 110 px give the
+trace more history to spread across.
+
+This is the one setting that keeps a reader running while the panel is closed.
+It stays deliberately cheap: only the resources snapshot is sampled, on a slower
+3 s cadence, and processes, GPU, storage, and power estimates stay off until you
+actually open the panel. Turn it back to Off and the plugin goes quiet again.
+
+One advanced override can be set directly on the widget's entry in
+`~/.config/omarchy/shell.json`, alongside the existing interval overrides:
+`backgroundRefreshIntervalMs` (1000–30000, default 3000).
 
 ## A few honest details
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "stappmus.activity-monitor",
   "name": "Activity Monitor",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "Kristoffer Haugland",
   "license": "MIT",
   "description": "A calm, low-overhead glance at CPU, memory, GPU, storage, and processes — with a die that matches your chip",
@@ -29,14 +29,20 @@
       "temperatureUnit": "Celsius",
       "showFrequencies": true,
       "openExpanded": false,
-      "processPowerEnabled": true
+      "processPowerEnabled": true,
+      "barGraph": "Off",
+      "barGraphLength": 0
     },
     "schema": [
       {
         "key": "samplingSpeed",
         "type": "enum",
         "label": "Update speed",
-        "options": ["Efficient", "Balanced", "Fast"],
+        "options": [
+          "Efficient",
+          "Balanced",
+          "Fast"
+        ],
         "defaultValue": "Balanced",
         "description": "Efficient uses fewer samples; Fast makes the graphs react sooner."
       },
@@ -53,8 +59,33 @@
         "key": "temperatureUnit",
         "type": "enum",
         "label": "Temperature unit",
-        "options": ["Celsius", "Fahrenheit"],
+        "options": [
+          "Celsius",
+          "Fahrenheit"
+        ],
         "defaultValue": "Celsius"
+      },
+      {
+        "key": "barGraph",
+        "type": "enum",
+        "label": "Bar graph",
+        "options": [
+          "Off",
+          "CPU",
+          "Memory"
+        ],
+        "defaultValue": "Off",
+        "description": "Draw a live sparkline beside the bar icon. Off keeps sampling to while the panel is open."
+      },
+      {
+        "key": "barGraphLength",
+        "type": "integer",
+        "label": "Bar graph width",
+        "min": 0,
+        "max": 160,
+        "step": 2,
+        "defaultValue": 0,
+        "description": "Length of the bar graph along the bar, in pixels. 0 matches the bar thickness for a square graph."
       },
       {
         "key": "showFrequencies",

--- a/test/activity-test.sh
+++ b/test/activity-test.sh
@@ -434,8 +434,13 @@ const manifest = requireFromRoot('manifest.json')
 const settingKeys = manifest.barWidget.schema.map(entry => entry.key)
 assertDeepEqual(
   settingKeys,
-  ['samplingSpeed', 'historySamples', 'temperatureUnit', 'showFrequencies', 'openExpanded', 'processPowerEnabled'],
+  ['samplingSpeed', 'historySamples', 'temperatureUnit', 'barGraph', 'barGraphLength', 'showFrequencies', 'openExpanded', 'processPowerEnabled'],
   'activity publishes the same focused preferences offered by its settings menu'
+)
+assertEqual(
+  manifest.barWidget.defaults.barGraph,
+  'Off',
+  'activity leaves the bar graph off until it is asked for'
 )
 JS
 
@@ -606,11 +611,19 @@ grep -Fq 'centerOnBar: false' "$ROOT/Panel.qml" ||
   fail "activity panel keeps compact and expanded layouts on the same bar anchor"
 pass "activity panel expansion preserves its bar anchor"
 
-grep -Fq 'implicitWidth: button.implicitWidth' "$ROOT/Panel.qml" ||
+grep -Eq 'implicitWidth: .*button\.implicitWidth' "$ROOT/Panel.qml" ||
   fail "activity bar widget does not expose its icon width"
-grep -Fq 'implicitHeight: button.implicitHeight' "$ROOT/Panel.qml" ||
+grep -Eq 'implicitHeight: .*button\.implicitHeight' "$ROOT/Panel.qml" ||
   fail "activity bar widget does not expose its icon height"
 pass "activity bar widget exposes its icon geometry"
+
+grep -Fq 'background: root.barGraphEnabled' "$ROOT/Panel.qml" ||
+  fail "activity bar graph does not drive the background sampling tier"
+grep -Fq 'readonly property bool sampling: active || background' "$ROOT/ActivityController.qml" ||
+  fail "activity controller does not gate sampling on the background tier"
+grep -Fq 'if (!active) return' "$ROOT/ActivityController.qml" ||
+  fail "activity controller fans out to every reader outside the open panel"
+pass "activity bar graph samples resources only while the panel is closed"
 
 grep -Fq 'id: headerActions' "$ROOT/Panel.qml" ||
   fail "activity header actions do not share a header row"
@@ -695,7 +708,7 @@ grep -Fq 'refreshProcessCycle()' "$controller_file" ||
   fail "activity panel does not coordinate energy and process refreshes"
 grep -Fq 'id: deadlineScheduler' "$controller_file" &&
   grep -Fq 'function collectDueSnapshots()' "$controller_file" &&
-  grep -Fq '_resourceDue = nextDeadline(_resourceDue, refreshInterval, now)' "$controller_file" &&
+  grep -Fq '_resourceDue = nextDeadline(_resourceDue, resourceInterval(), now)' "$controller_file" &&
   grep -Fq '_processDue = nextDeadline(_processDue, processRefreshInterval, now)' "$controller_file" &&
   grep -Fq '_thermalDue = nextDeadline(_thermalDue, thermalRefreshInterval, now)' "$controller_file" &&
   grep -Fq '_gpuDue = nextDeadline(_gpuDue, gpuRefreshInterval, now)' "$controller_file" &&


### PR DESCRIPTION
Replaces the bar icon with a live sparkline when enabled. Off by default.

The plugin is built to go quiet when the panel is closed, so the graph gets its
own sampling tier: with the panel closed it reads only the resources snapshot,
on a slower 3 s cadence. Processes, thermals, GPU, storage, and power estimates
stay gated on an open panel, the same way GPU sampling is already gated on
`expanded`. With the graph off, nothing runs while the panel is closed.

It draws through `BarIconButton`'s `iconComponent` rather than its own
MouseArea, since `ModuleSlot` dispatches presses only to items registered via
`registerClickTarget()` — a bare MouseArea receives nothing, and hiding the icon
to make room would deregister the widget's only click target. Hover reports CPU
and RAM together.

Two new preferences: **Bar graph** (Off / CPU / Memory) and **Bar graph width**
(square, matching the slot the icon occupied, or 44 / 72 / 110 px).
`backgroundRefreshIntervalMs` stays an unpublished `shell.json` override,
matching `refreshIntervalMs` and friends. The settings page cap moves 720 → 860
so the extra row fits; that page doesn't scroll, so overflow hides controls
rather than cropping them.

Tested: `./test/all.sh` 251 pass, with existing assertions updated where the
change made them stale and new coverage for the background tier and the
default-off contract. `omarchy plugin validate .` clean, no new qmllint
warnings.

In the spirit of agentic coding in Omarchy, this was implemented with Claude
Code using Opus 5.

[
<img width="938" height="750" alt="shot_settings" src="https://github.com/user-attachments/assets/6aa5d687-9008-4ae0-9cda-3f75d6856a42" />
<img width="1500" height="120" alt="shot_off" src="https://github.com/user-attachments/assets/3b9afebc-4376-4335-85d0-7159a6291296" />
<img width="1500" height="120" alt="shot_wide" src="https://github.com/user-attachments/assets/d68c81a4-3d11-49a5-a645-7007cc2145e5" />
<img width="1500" height="120" alt="shot_square" src="https://github.com/user-attachments/assets/a60c98dd-5585-4d06-9eed-e83cad9b917e" />
](url)